### PR TITLE
Replace sleep with scheduled event

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,16 +50,17 @@ class WifiConnect(MycroftSkill):
                 "Device has previously connected to a network. Delaying Wifi "
                 "to provide system time to connect to slower Wifi networks."
             )
-            sleep(25)
+            delay = 25
         else:
             # Give the GUI and Wifi Connect time to get started.
-            sleep(5)
-        if not connected():
-            self.show_all_screens()
+            delay = 5
+        self.schedule_event(self.show_all_screens, delay)
 
     @intent_handler("test.intent")
     def show_all_screens(self, _=None):
         """Show UI screens at a consistent interval."""
+        if connected():
+            return
         steps = [
             self.prompt_to_join_ap,
             self.prompt_to_sign_in_to_ap,


### PR DESCRIPTION
#### Description
The hard sleep prevented the Skill from report as loaded delaying all other Skills from starting to load. Shifting this out of the initialize method allows the Skill to report loaded and then return to perform it's expected function.

#### Type of PR
- [x] Bugfix

#### Testing
Even with the network connected, restart the Skills service and watch the Wifi Connect Skill load and block the rest of the service startup.